### PR TITLE
Add Cu(111) and Cu3Sn(0001) thermo data for CO2RR 

### DIFF
--- a/input/thermo/libraries/CO2RR_Adsorbates_Cu111.py
+++ b/input/thermo/libraries/CO2RR_Adsorbates_Cu111.py
@@ -1,0 +1,556 @@
+#!/usr/bin/env python
+# encoding: utf-8
+
+name = "CO2RR_Adsorbates_Cu111"
+solvent = "water"
+shortDesc = u"Place holder for short description"
+longDesc = u"""
+Place holder for long description
+"""
+
+entry(
+    index = 0,
+    label = "CH2OHX",
+    molecule =
+"""
+1 O u0 p2 c0 {2,S} {5,S}
+2 C u0 p0 c0 {1,S} {3,S} {4,S} {6,S}
+3 H u0 p0 c0 {2,S}
+4 H u0 p0 c0 {2,S}
+5 H u0 p0 c0 {1,S}
+6 X u0 p0 c0 {2,S}
+""",
+    thermo = NASA(
+    polynomials = [
+        NASAPolynomial(coeffs=[0.472735789, 0.0241008939, -2.46801184e-05, 1.37773161e-08, -3.0813789e-12, -21157.4578, 2.60923861], Tmin=(298.0, 'K'), Tmax=(1000.0, 'K')),
+        NASAPolynomial(coeffs=[10.5681808, -0.00792065082, 1.40261804e-05, -7.39838131e-09, 1.31411936e-12, -23729.4054, -48.4995382], Tmin=(1000.0, 'K'), Tmax=(2000.0, 'K')),
+    ],
+    Tmin=(298.0, 'K'),
+    Tmax=(2000.0, 'K'),
+),
+    shortDesc = u"""CH2OHX""",
+    longDesc =
+u"""Calculated by Torrie Asifor at Northeastern University using Statistical Mechanics. Based on DFT calculations by Colin Gallagher at Northeastern University
+""",
+    metal = "Cu",
+    facet = "111",
+)
+
+
+entry(
+    index = 1,
+    label = "CH2X",
+    molecule =
+"""
+1 C u0 p0 c0 {2,S} {3,S} {4,D}
+2 H u0 p0 c0 {1,S}
+3 H u0 p0 c0 {1,S}
+4 X u0 p0 c0 {1,D}
+""",
+    thermo = NASA(
+    polynomials = [
+        NASAPolynomial(coeffs=[0.466416892, 0.0226076886, -3.69343557e-05, 3.09744704e-08, -9.99641342e-12, 8004.29404, -3.72629114], Tmin=(298.0, 'K'), Tmax=(1000.0, 'K')),
+        NASAPolynomial(coeffs=[7.09877494, -0.00433095407, 7.66695886e-06, -4.02988705e-09, 7.12914077e-13, 6583.37634, -35.9122248], Tmin=(1000.0, 'K'), Tmax=(2000.0, 'K')),
+    ],
+    Tmin=(298.0, 'K'),
+    Tmax=(2000.0, 'K'),
+),
+    shortDesc = u"""CH2X""",
+    longDesc =
+u"""Calculated by Torrie Asifor at Northeastern University using Statistical Mechanics. Based on DFT calculations by Colin Gallagher at Northeastern University
+""",
+    metal = "Cu",
+    facet = "111",
+)
+
+
+entry(
+    index = 2,
+    label = "CH3X",
+    molecule =
+"""
+1 C u0 p0 c0 {2,S} {3,S} {4,S} {5,S}
+2 H u0 p0 c0 {1,S}
+3 H u0 p0 c0 {1,S}
+4 H u0 p0 c0 {1,S}
+5 X u0 p0 c0 {1,S}
+""",
+    thermo = NASA(
+    polynomials = [
+        NASAPolynomial(coeffs=[0.797287316, 0.0196521154, -2.31595564e-05, 1.66221917e-08, -4.97799024e-12, -3111.00157, -4.77956538], Tmin=(298.0, 'K'), Tmax=(1000.0, 'K')),
+        NASAPolynomial(coeffs=[8.91016513, -0.00741666648, 1.31686499e-05, -6.96776478e-09, 1.239664e-12, -5144.93228, -45.607756], Tmin=(1000.0, 'K'), Tmax=(2000.0, 'K')),
+    ],
+    Tmin=(298.0, 'K'),
+    Tmax=(2000.0, 'K'),
+),
+    shortDesc = u"""CH3X""",
+    longDesc =
+u"""Calculated by Torrie Asifor at Northeastern University using Statistical Mechanics. Based on DFT calculations by Colin Gallagher at Northeastern University
+""",
+    metal = "Cu",
+    facet = "111",
+)
+
+
+entry(
+    index = 3,
+    label = "CHOHX",
+    molecule =
+"""
+1 O u0 p2 c0 {2,S} {4,S}
+2 C u0 p0 c0 {1,S} {3,S} {5,D}
+3 H u0 p0 c0 {2,S}
+4 H u0 p0 c0 {1,S}
+5 X u0 p0 c0 {2,D}
+""",
+    thermo = NASA(
+    polynomials = [
+        NASAPolynomial(coeffs=[1.41019307, 0.0224007435, -2.72300418e-05, 1.76532667e-08, -4.60273486e-12, -11957.2586, -6.3198189], Tmin=(298.0, 'K'), Tmax=(1000.0, 'K')),
+        NASAPolynomial(coeffs=[9.6152098, -0.00536925487, 9.50116088e-06, -5.00366325e-09, 8.87974014e-13, -13954.9197, -47.4140367], Tmin=(1000.0, 'K'), Tmax=(2000.0, 'K')),
+    ],
+    Tmin=(298.0, 'K'),
+    Tmax=(2000.0, 'K'),
+),
+    shortDesc = u"""CHOHX""",
+    longDesc =
+u"""Calculated by Torrie Asifor at Northeastern University using Statistical Mechanics. Based on DFT calculations by Colin Gallagher at Northeastern University
+""",
+    metal = "Cu",
+    facet = "111",
+)
+
+
+entry(
+    index = 4,
+    label = "CHOX",
+    molecule =
+"""
+1 O u0 p2 c0 {2,D}
+2 C u0 p0 c0 {1,D} {3,S} {4,S}
+3 H u0 p0 c0 {2,S}
+4 X u0 p0 c0 {2,S}
+""",
+    thermo = NASA(
+    polynomials = [
+        NASAPolynomial(coeffs=[2.37863592, 0.012408481, -1.25801919e-05, 7.24790581e-09, -1.8141235e-12, -13935.0226, -9.04256939], Tmin=(298.0, 'K'), Tmax=(1000.0, 'K')),
+        NASAPolynomial(coeffs=[7.62620563, -0.00385204041, 6.94355702e-06, -3.75812385e-09, 6.81108837e-13, -15307.787, -35.7479814], Tmin=(1000.0, 'K'), Tmax=(2000.0, 'K')),
+    ],
+    Tmin=(298.0, 'K'),
+    Tmax=(2000.0, 'K'),
+),
+    shortDesc = u"""CHOX""",
+    longDesc =
+u"""Calculated by Torrie Asifor at Northeastern University using Statistical Mechanics. Based on DFT calculations by Colin Gallagher at Northeastern University
+""",
+    metal = "Cu",
+    facet = "111",
+)
+
+
+entry(
+    index = 5,
+    label = "CHX",
+    molecule =
+"""
+1 C u0 p0 c0 {2,S} {3,T}
+2 H u0 p0 c0 {1,S}
+3 X u0 p0 c0 {1,T}
+""",
+    thermo = NASA(
+    polynomials = [
+        NASAPolynomial(coeffs=[-2.08855354, 0.0294663183, -5.2247455e-05, 4.3854041e-08, -1.3978891e-11, 15687.781, 6.79987743], Tmin=(298.0, 'K'), Tmax=(1000.0, 'K')),
+        NASAPolynomial(coeffs=[4.98902907, -0.00223592875, 3.9741247e-06, -2.09265476e-09, 3.70889503e-13, 14337.5132, -26.7707539], Tmin=(1000.0, 'K'), Tmax=(2000.0, 'K')),
+    ],
+    Tmin=(298.0, 'K'),
+    Tmax=(2000.0, 'K'),
+),
+    shortDesc = u"""CHX""",
+    longDesc =
+u"""Calculated by Torrie Asifor at Northeastern University using Statistical Mechanics. Based on DFT calculations by Colin Gallagher at Northeastern University
+""",
+    metal = "Cu",
+    facet = "111",
+)
+
+
+entry(
+    index = 6,
+    label = "COCHOX",
+    molecule =
+"""
+1 O u0 p2 c0 {3,D}
+2 O u0 p2 c0 {4,D}
+3 C u0 p0 c0 {1,D} {4,S} {5,S}
+4 C u0 p0 c0 {2,D} {3,S} {6,S}
+5 H u0 p0 c0 {3,S}
+6 X u0 p0 c0 {4,S}
+""",
+    thermo = NASA(
+    polynomials = [
+        NASAPolynomial(coeffs=[1.93949246, 0.0256383446, -2.77539412e-05, 1.63477437e-08, -4.11348733e-12, -34804.6135, -3.52046277], Tmin=(298.0, 'K'), Tmax=(1000.0, 'K')),
+        NASAPolynomial(coeffs=[12.0315845, -0.00610743143, 1.11113129e-05, -6.09316938e-09, 1.11585568e-12, -37414.5425, -54.7480472], Tmin=(1000.0, 'K'), Tmax=(2000.0, 'K')),
+    ],
+    Tmin=(298.0, 'K'),
+    Tmax=(2000.0, 'K'),
+),
+    shortDesc = u"""COCHOX""",
+    longDesc =
+u"""Calculated by Torrie Asifor at Northeastern University using Statistical Mechanics. Based on DFT calculations by Colin Gallagher at Northeastern University
+""",
+    metal = "Cu",
+    facet = "111",
+)
+
+
+entry(
+    index = 7,
+    label = "COHX",
+    molecule =
+"""
+1 O u0 p2 c0 {2,S} {3,S}
+2 C u0 p0 c0 {1,S} {4,T}
+3 H u0 p0 c0 {1,S}
+4 X u0 p0 c0 {2,T}
+""",
+    thermo = NASA(
+    polynomials = [
+        NASAPolynomial(coeffs=[1.88601171, 0.0175443623, -2.3496585e-05, 1.60954951e-08, -4.3767108e-12, -10766.6389, -8.99891253], Tmin=(298.0, 'K'), Tmax=(1000.0, 'K')),
+        NASAPolynomial(coeffs=[7.64233194, -0.00292695859, 5.17262432e-06, -2.71697657e-09, 4.81552239e-13, -12112.2365, -37.5691896], Tmin=(1000.0, 'K'), Tmax=(2000.0, 'K')),
+    ],
+    Tmin=(298.0, 'K'),
+    Tmax=(2000.0, 'K'),
+),
+    shortDesc = u"""COHX""",
+    longDesc =
+u"""Calculated by Torrie Asifor at Northeastern University using Statistical Mechanics. Based on DFT calculations by Colin Gallagher at Northeastern University
+""",
+    metal = "Cu",
+    facet = "111",
+)
+
+
+entry(
+    index = 8,
+    label = "COOHX",
+    molecule =
+"""
+1 O u0 p2 c0 {3,S} {4,S}
+2 O u0 p2 c0 {3,D}
+3 C u0 p0 c0 {1,S} {2,D} {5,S}
+4 H u0 p0 c0 {1,S} 
+5 X u0 p0 c0 {3,S}
+""",
+    thermo = NASA(
+    polynomials = [
+        NASAPolynomial(coeffs=[1.05917125, 0.0219066236, -2.43200647e-05, 1.36437162e-08, -3.01907804e-12, -48232.3178, 0.75905578], Tmin=(298.0, 'K'), Tmax=(1000.0, 'K')),
+        NASAPolynomial(coeffs=[9.25517481, -0.00446613856, 8.00866345e-06, -4.303982e-09, 7.76650481e-13, -50290.4042, -40.6148991], Tmin=(1000.0, 'K'), Tmax=(2000.0, 'K')),
+    ],
+    Tmin=(298.0, 'K'),
+    Tmax=(2000.0, 'K'),
+),
+    shortDesc = u"""COOHX""",
+    longDesc =
+u"""Calculated by Torrie Asifor at Northeastern University using Statistical Mechanics. Based on DFT calculations by Colin Gallagher at Northeastern University
+""",
+    metal = "Cu",
+    facet = "111",
+)
+
+
+entry(
+    index = 9,
+    label = "COX",
+    molecule =
+"""
+1 O u0 p2 c0 {2,D}
+2 C u0 p0 c0 {1,D} {3,D}
+3 X u0 p0 c0 {2,D} 
+""",
+    thermo = NASA(
+    polynomials = [
+        NASAPolynomial(coeffs=[3.52678302, 0.00519878526, -6.77403179e-06, 5.45808928e-09, -1.86754692e-12, -22933.4167, -15.777435], Tmin=(298.0, 'K'), Tmax=(1000.0, 'K')),
+        NASAPolynomial(coeffs=[5.53299166, -0.00147915536, 2.70209812e-06, -1.4866849e-09, 2.72829319e-13, -23451.2467, -25.9161271], Tmin=(1000.0, 'K'), Tmax=(2000.0, 'K')),
+    ],
+    Tmin=(298.0, 'K'),
+    Tmax=(2000.0, 'K'),
+),
+    shortDesc = u"""COX""",
+    longDesc =
+u"""Calculated by Torrie Asifor at Northeastern University using Statistical Mechanics. Based on DFT calculations by Colin Gallagher at Northeastern University
+""",
+    metal = "Cu",
+    facet = "111",
+)
+
+
+entry(
+    index = 10,
+    label = "OCH2CH3X",
+    molecule =
+"""
+1 O u0 p2 c0 {2,S} {9,S}
+2 C u0 p0 c0 {1,S} {3,S} {4,S} {5,S}
+3 C u0 p0 c0 {2,S} {6,S} {7,S} {8,S}
+4 H u0 p0 c0 {2,S}
+5 H u0 p0 c0 {2,S}
+6 H u0 p0 c0 {3,S}
+7 H u0 p0 c0 {3,S}
+8 H u0 p0 c0 {3,S}
+9 X u0 p0 c0 {1,S}
+""",
+    thermo = NASA(
+    polynomials = [
+        NASAPolynomial(coeffs=[0.526183454, 0.0258797543, -4.36025144e-06, -1.14542255e-08, 6.25217239e-12, -36161.4155, 3.24649437], Tmin=(298.0, 'K'), Tmax=(1000.0, 'K')),
+        NASAPolynomial(coeffs=[16.8038419, -0.0159680235, 2.8516839e-05, -1.52454216e-08, 2.73639731e-12, -40823.2612, -81.6436784], Tmin=(1000.0, 'K'), Tmax=(2000.0, 'K')),
+    ],
+    Tmin=(298.0, 'K'),
+    Tmax=(2000.0, 'K'),
+),
+    shortDesc = u"""OCH2CH3X""",
+    longDesc =
+u"""Calculated by Torrie Asifor at Northeastern University using Statistical Mechanics. Based on DFT calculations by Colin Gallagher at Northeastern University
+""",
+    metal = "Cu",
+    facet = "111",
+)
+
+
+entry(
+    index = 11,
+    label = "OCHCH2OHX",
+    molecule =
+"""
+1 O u0 p2 c0 {3,S} {8,S}
+2 O u0 p2 c0 {4,D}
+3 C u0 p0 c0 {1,S} {4,S} {5,S} {6,S}
+4 C u0 p0 c0 {2,D} {3,S} {7,S}
+5 H u0 p0 c0 {3,S}
+6 H u0 p0 c0 {3,S}
+7 H u0 p0 c0 {4,S}
+8 H u0 p0 c0 {1,S}
+9 X u0 p0 c0 
+""",
+    thermo = NASA(
+    polynomials = [
+        NASAPolynomial(coeffs=[3.09646829, 0.0237384116, -3.87127221e-06, -1.13323939e-08, 6.16656379e-12, -46953.0529, -4.1727781], Tmin=(298.0, 'K'), Tmax=(1000.0, 'K')),
+        NASAPolynomial(coeffs=[17.7632799, -0.0135012658, 2.41421777e-05, -1.29323226e-08, 2.32590842e-12, -51169.7292, -80.7610976], Tmin=(1000.0, 'K'), Tmax=(2000.0, 'K')),
+    ],
+    Tmin=(298.0, 'K'),
+    Tmax=(2000.0, 'K'),
+),
+    shortDesc = u"""OCHCH2OHX""",
+    longDesc =
+u"""Calculated by Torrie Asifor at Northeastern University using Statistical Mechanics. Based on DFT calculations by Colin Gallagher at Northeastern University
+""",
+    metal = "Cu",
+    facet = "111",
+)
+
+
+entry(
+    index = 12,
+    label = "OCHCH2X",
+    molecule =
+"""
+1 O u0 p2 c0 {2,S} {7,S}
+2 C u0 p0 c0 {1,S} {3,D} {4,S}
+3 C u0 p0 c0 {2,D} {5,S} {6,S}
+4 H u0 p0 c0 {2,S}
+5 H u0 p0 c0 {3,S}
+6 H u0 p0 c0 {3,S}
+7 X u0 p0 c0 {1,S}
+""",
+    thermo = NASA(
+    polynomials = [
+        NASAPolynomial(coeffs=[-0.628328912, 0.0328527253, -3.1908806e-05, 1.59572749e-08, -3.05474396e-12, -23681.7878, 7.83815501], Tmin=(298.0, 'K'), Tmax=(1000.0, 'K')),
+        NASAPolynomial(coeffs=[13.1893158, -0.00985950398, 1.76359697e-05, -9.44590688e-09, 1.69824677e-12, -27258.0458, -62.3914324], Tmin=(1000.0, 'K'), Tmax=(2000.0, 'K')),
+    ],
+    Tmin=(298.0, 'K'),
+    Tmax=(2000.0, 'K'),
+),
+    shortDesc = u"""OCHCH2X""",
+    longDesc =
+u"""Calculated by Torrie Asifor at Northeastern University using Statistical Mechanics. Based on DFT calculations by Colin Gallagher at Northeastern University
+""",
+    metal = "Cu",
+    facet = "111",
+)
+
+
+entry(
+    index = 13,
+    label = "OCHCH3X",
+    molecule =
+"""
+1 O u0 p2 c0 {3,D} 
+2 C u0 p0 c0 {3,S} {4,S} {5,S} {6,S}
+3 C u0 p0 c0 {1,D} {2,S} {7,S}
+4 H u0 p0 c0 {2,S}
+5 H u0 p0 c0 {2,S}
+6 H u0 p0 c0 {2,S}
+7 H u0 p0 c0 {3,S}
+8 X u0 p0 c0 
+""",
+    thermo = NASA(
+    polynomials = [
+        NASAPolynomial(coeffs=[2.93148616, 0.0156994161, 5.27680207e-06, -1.57739035e-08, 6.86352711e-12, -27771.7175, -4.21488209], Tmin=(298.0, 'K'), Tmax=(1000.0, 'K')),
+        NASAPolynomial(coeffs=[14.9647333, -0.0130728691, 2.33574302e-05, -1.24959647e-08, 2.24399815e-12, -31341.2771, -67.5434017], Tmin=(1000.0, 'K'), Tmax=(2000.0, 'K')),
+    ],
+    Tmin=(298.0, 'K'),
+    Tmax=(2000.0, 'K'),
+),
+    shortDesc = u"""OCHCH3X""",
+    longDesc =
+u"""Calculated by Torrie Asifor at Northeastern University using Statistical Mechanics. Based on DFT calculations by Colin Gallagher at Northeastern University
+""",
+    metal = "Cu",
+    facet = "111",
+)
+
+
+entry(
+    index = 14,
+    label = "OCHCHOHX",
+    molecule =
+"""
+1 O u0 p2 c0 {3,S} {8,S}
+2 O u0 p2 c0 {4,S} {7,S} 
+3 C u0 p0 c0 {1,S} {4,D} {5,S}
+4 C u0 p0 c0 {2,S} {3,D} {6,S}
+5 H u0 p0 c0 {3,S}
+6 H u0 p0 c0 {4,S}
+7 H u0 p0 c0 {2,S}
+8 X u0 p0 c0 {1,S}
+""",
+    thermo = NASA(
+    polynomials = [
+        NASAPolynomial(coeffs=[0.00911478161, 0.0397758564, -4.14240749e-05, 2.21262211e-08, -4.59902949e-12, -44975.5239, 5.06918604], Tmin=(298.0, 'K'), Tmax=(1000.0, 'K')),
+        NASAPolynomial(coeffs=[15.8574169, -0.0102903723, 1.83673581e-05, -9.80550942e-09, 1.75919459e-12, -49009.9016, -75.1821401], Tmin=(1000.0, 'K'), Tmax=(2000.0, 'K')),
+    ],
+    Tmin=(298.0, 'K'),
+    Tmax=(2000.0, 'K'),
+),
+    shortDesc = u"""OCHCHOHX""",
+    longDesc =
+u"""Calculated by Torrie Asifor at Northeastern University using Statistical Mechanics. Based on DFT calculations by Colin Gallagher at Northeastern University
+""",
+    metal = "Cu",
+    facet = "111",
+)
+
+
+entry(
+    index = 15,
+    label = "OCHCHX",
+    molecule =
+"""
+1 O u0 p2 c0 {3,D}
+2 C u0 p0 c0 {3,S} {4,S} {6,D}
+3 C u0 p0 c0 {1,D} {2,S} {5,S}
+4 H u0 p0 c0 {2,S}
+5 H u0 p0 c0 {3,S}
+6 X u0 p0 c0 {2,D}
+""",
+    thermo = NASA(
+    polynomials = [
+        NASAPolynomial(coeffs=[0.276809443, 0.0301374978, -3.16219676e-05, 1.72227608e-08, -3.75111053e-12, -18198.9697, -1.71302897], Tmin=(298.0, 'K'), Tmax=(1000.0, 'K')),
+        NASAPolynomial(coeffs=[12.2388819, -0.00757866622, 1.36344476e-05, -7.36324538e-09, 1.33257199e-12, -21258.6668, -62.3317273], Tmin=(1000.0, 'K'), Tmax=(2000.0, 'K')),
+    ],
+    Tmin=(298.0, 'K'),
+    Tmax=(2000.0, 'K'),
+),
+    shortDesc = u"""OCHCHX""",
+    longDesc =
+u"""Calculated by Torrie Asifor at Northeastern University using Statistical Mechanics. Based on DFT calculations by Colin Gallagher at Northeastern University
+""",
+    metal = "Cu",
+    facet = "111",
+)
+
+
+entry(
+    index = 16,
+    label = "OCHOCHX",
+    molecule =
+"""
+1 O u0 p2 c0 {3,S} {7,S}
+2 O u0 p2 c0 {4,S} {8,S} 
+3 C u0 p0 c0 {1,S} {4,D} {5,S}
+4 C u0 p0 c0 {2,S} {3,D} {6,S}
+5 H u0 p0 c0 {3,S}
+6 H u0 p0 c0 {4,S}
+7 X u0 p0 c0 {1,S}
+8 X u0 p0 c0 {2,S}
+""",
+    thermo = NASA(
+    polynomials = [
+        NASAPolynomial(coeffs=[-0.188361028, 0.0359884107, -3.77327255e-05, 2.00961226e-08, -4.20161128e-12, -41417.7273, 5.73697635], Tmin=(298.0, 'K'), Tmax=(1000.0, 'K')),
+        NASAPolynomial(coeffs=[13.933618, -0.00846409226, 1.52416698e-05, -8.24316109e-09, 1.493801e-12, -45025.8482, -65.8263189], Tmin=(1000.0, 'K'), Tmax=(2000.0, 'K')),
+    ],
+    Tmin=(298.0, 'K'),
+    Tmax=(2000.0, 'K'),
+),
+    shortDesc = u"""OCHOCHX""",
+    longDesc =
+u"""Calculated by Torrie Asifor at Northeastern University using Statistical Mechanics. Based on DFT calculations by Colin Gallagher at Northeastern University
+""",
+    metal = "Cu",
+    facet = "111",
+)
+
+
+entry(
+    index = 17,
+    label = "OCHOX",
+    molecule =
+"""
+1 O u0 p2 c0 {3,S} {5,S}
+2 O u0 p2 c0 {3,D} 
+3 C u0 p0 c0 {1,S} {2,D} {4,S}
+4 H u0 p0 c0 {3,S}
+5 X u0 p0 c0 {1,S}
+""",
+    thermo = NASA(
+    polynomials = [
+        NASAPolynomial(coeffs=[1.6663831, 0.0145773007, -7.54839692e-06, -1.28850802e-09, 1.76379918e-12, -56459.297, -1.41903333], Tmin=(298.0, 'K'), Tmax=(1000.0, 'K')),
+        NASAPolynomial(coeffs=[9.15358298, -0.00545271031, 9.86437499e-06, -5.37406014e-09, 9.79390495e-13, -58557.4789, -40.2571999], Tmin=(1000.0, 'K'), Tmax=(2000.0, 'K')),
+    ],
+    Tmin=(298.0, 'K'),
+    Tmax=(2000.0, 'K'),
+),
+    shortDesc = u"""OCHOX""",
+    longDesc =
+u"""Calculated by Torrie Asifor at Northeastern University using Statistical Mechanics. Based on DFT calculations by Colin Gallagher at Northeastern University
+""",
+    metal = "Cu",
+    facet = "111",
+)
+
+
+entry(
+    index = 18,
+    label = "XCOXCO",
+    molecule =
+"""
+1 O u0 p2 c0 {3,D}
+2 O u0 p2 c0 {4,D}
+3 C u0 p0 c0 {1,D} {4,S} {5,S}
+4 C u0 p0 c0 {2,D} {3,S} {6,S}
+5 X u0 p0 c0 {3,S}
+6 X u0 p0 c0 {4,S}
+""",
+    thermo = NASA(
+    polynomials = [
+        NASAPolynomial(coeffs=[2.49554898, 0.0242026474, -3.27700315e-05, 2.26836821e-08, -6.38929534e-12, -25528.1387, -6.08127138], Tmin=(298.0, 'K'), Tmax=(1000.0, 'K')),
+        NASAPolynomial(coeffs=[10.2047191, -0.00286178768, 5.28404531e-06, -2.95345619e-09, 5.49031049e-13, -27368.1643, -44.4858043], Tmin=(1000.0, 'K'), Tmax=(2000.0, 'K')),
+    ],
+    Tmin=(298.0, 'K'),
+    Tmax=(2000.0, 'K'),
+),
+    shortDesc = u"""XCOXCO""",
+    longDesc =
+u"""Calculated by Torrie Asifor at Northeastern University using Statistical Mechanics. Based on DFT calculations by Colin Gallagher at Northeastern University
+""",
+    metal = "Cu",
+    facet = "111",
+)

--- a/input/thermo/libraries/CO2RR_Adsorbates_Cu111.py
+++ b/input/thermo/libraries/CO2RR_Adsorbates_Cu111.py
@@ -2,10 +2,55 @@
 # encoding: utf-8
 
 name = "CO2RR_Adsorbates_Cu111"
-solvent = "water"
-shortDesc = u"Place holder for short description"
-longDesc = u"""
-Place holder for long description
+shortDesc = "CO2RR adsorbate thermochemistry on Cu(111) from DFT"
+longDesc = """
+NASA polynomial thermochemistry for C1 and C2 adsorbate intermediates
+relevant to electrochemical CO2 reduction (CO2RR) on Cu(111). Species
+include CHX, CH2X, CH3X, CHOX, CHOHX, CH2OHX, COX, COHX, COOHX, OCHOX,
+COCHOX, OCHCHX, OCHCH2X, OCHCH3X, OCHCHOHX, OCHCH2OHX, OCHOCHX, OCH2CH3X,
+and the C-C coupled XCOXCO dimer. Adsorbates are labeled with a trailing
+or interleaved 'X' to indicate surface binding sites, per RMG conventions.
+
+DFT (Colin Gallagher, Northeastern): VASP with PBE + Grimme D3 zero-damping
+(IVDW = 12) and PAW pseudopotentials. A two-stage protocol was used:
+initial geometries were pre-optimized at ENCUT = 400 eV with a 3x3x1
+Monkhorst-Pack k-mesh, then fully re-relaxed to force convergence at
+tighter settings of ENCUT = 500 eV and 4x4x1 k-mesh (IBRION = 2,
+EDIFFG = -0.03 eV/A). All final energies - adsorbate slabs, bare-slab
+reference, and vibrational frequencies - were computed at the tight
+settings. Other parameters: 1st order Methfessel-Paxton smearing
+(ISMEAR = 1) with a smearing width of 0.1 eV, ISPIN = 2,
+EDIFF = 1E-6 eV, no dipole correction. Slab: 4x4 Cu(111), 4 layers
+(64 Cu), bottom 2 fixed and top 2 relaxed, in-plane area 86.32 A^2,
+~18 A vacuum. Harmonic frequencies from finite differences (IBRION = 5,
+NFREE = 2, POTIM = 0.015 A) on the free atoms (adsorbate + top 2 layers).
+
+Post-processing and thermo (Torrie Asifor) via the Westgroup pipeline
+(adapted from input_generator.py and compute_NASA_for_adsorbates): VASP
+outputs converted to ASE .traj and inspected; vibrational frequencies
+and ZPEs consolidated into per-species zpe_log_<species>.txt files;
+imaginary modes replaced with 12 cm^-1. Heat of formation at 0 K was
+computed from a thermochemical cycle against CH4, H2O, and H2 references
+(ATcT: h0_CH4 = -66.556 kJ/mol, h0_H2O = -238.938 kJ/mol,
+h0_H2 = 0.0 kJ/mol). Reference gas electronic energies were read from the
+final frame of each gas's ads_vib.traj at the same PBE+D3 level as the
+slabs (displaced rather than relaxed geometries, a systematic ~1 kJ/mol
+offset shared across all species); hard-coded ZPEs ZPE_CH4 = 1.196 eV,
+ZPE_H2 = 0.277 eV, ZPE_H2O = 0.609 eV were used. Partition functions
+were evaluated over 298.15-2000 K with the harmonic oscillator
+approximation; when an adsorbate's two lowest modes fall below 100 cm^-1
+they are replaced by a 2D-gas translational model using a legacy per-site
+area of 6.90 A^2/site inherited from earlier 3x3 Cu(111) workflows (vs.
+the actual 5.40 A^2/site for this 4x4 slab, a ~0.6 kJ/mol shift at 298 K).
+NASA polynomials were fit in two ranges (298-1000 K, 1000-2000 K) by
+least-squares regression of Cp/R with enthalpy and entropy matched at
+298.15 K and continuity enforced at 1000 K. Heats of formation were
+corrected from 0 K to 298 K using tabulated atomic H(298)-H(0) increments.
+
+Intended as a supporting thermo reference for RMG-generated CO2RR
+mechanisms on Cu(111), where extensive benchmarks exist. Uncertainty is
+consistent with typical PBE+D3 performance on transition-metal adsorbates
+(~0.2 eV, ~20 kJ/mol per species).
 """
 
 entry(
@@ -30,7 +75,7 @@ entry(
 ),
     shortDesc = u"""CH2OHX""",
     longDesc =
-u"""Calculated by Torrie Asifor at Northeastern University using Statistical Mechanics. Based on DFT calculations by Colin Gallagher at Northeastern University
+u"""
 """,
     metal = "Cu",
     facet = "111",
@@ -57,7 +102,7 @@ entry(
 ),
     shortDesc = u"""CH2X""",
     longDesc =
-u"""Calculated by Torrie Asifor at Northeastern University using Statistical Mechanics. Based on DFT calculations by Colin Gallagher at Northeastern University
+u"""
 """,
     metal = "Cu",
     facet = "111",
@@ -85,7 +130,7 @@ entry(
 ),
     shortDesc = u"""CH3X""",
     longDesc =
-u"""Calculated by Torrie Asifor at Northeastern University using Statistical Mechanics. Based on DFT calculations by Colin Gallagher at Northeastern University
+u"""
 """,
     metal = "Cu",
     facet = "111",
@@ -113,7 +158,7 @@ entry(
 ),
     shortDesc = u"""CHOHX""",
     longDesc =
-u"""Calculated by Torrie Asifor at Northeastern University using Statistical Mechanics. Based on DFT calculations by Colin Gallagher at Northeastern University
+u"""
 """,
     metal = "Cu",
     facet = "111",
@@ -140,7 +185,7 @@ entry(
 ),
     shortDesc = u"""CHOX""",
     longDesc =
-u"""Calculated by Torrie Asifor at Northeastern University using Statistical Mechanics. Based on DFT calculations by Colin Gallagher at Northeastern University
+u"""
 """,
     metal = "Cu",
     facet = "111",
@@ -166,7 +211,7 @@ entry(
 ),
     shortDesc = u"""CHX""",
     longDesc =
-u"""Calculated by Torrie Asifor at Northeastern University using Statistical Mechanics. Based on DFT calculations by Colin Gallagher at Northeastern University
+u"""
 """,
     metal = "Cu",
     facet = "111",
@@ -195,7 +240,7 @@ entry(
 ),
     shortDesc = u"""COCHOX""",
     longDesc =
-u"""Calculated by Torrie Asifor at Northeastern University using Statistical Mechanics. Based on DFT calculations by Colin Gallagher at Northeastern University
+u"""
 """,
     metal = "Cu",
     facet = "111",
@@ -222,7 +267,7 @@ entry(
 ),
     shortDesc = u"""COHX""",
     longDesc =
-u"""Calculated by Torrie Asifor at Northeastern University using Statistical Mechanics. Based on DFT calculations by Colin Gallagher at Northeastern University
+u"""
 """,
     metal = "Cu",
     facet = "111",
@@ -250,7 +295,7 @@ entry(
 ),
     shortDesc = u"""COOHX""",
     longDesc =
-u"""Calculated by Torrie Asifor at Northeastern University using Statistical Mechanics. Based on DFT calculations by Colin Gallagher at Northeastern University
+u"""
 """,
     metal = "Cu",
     facet = "111",
@@ -276,7 +321,7 @@ entry(
 ),
     shortDesc = u"""COX""",
     longDesc =
-u"""Calculated by Torrie Asifor at Northeastern University using Statistical Mechanics. Based on DFT calculations by Colin Gallagher at Northeastern University
+u"""
 """,
     metal = "Cu",
     facet = "111",
@@ -308,7 +353,7 @@ entry(
 ),
     shortDesc = u"""OCH2CH3X""",
     longDesc =
-u"""Calculated by Torrie Asifor at Northeastern University using Statistical Mechanics. Based on DFT calculations by Colin Gallagher at Northeastern University
+u"""
 """,
     metal = "Cu",
     facet = "111",
@@ -340,7 +385,7 @@ entry(
 ),
     shortDesc = u"""OCHCH2OHX""",
     longDesc =
-u"""Calculated by Torrie Asifor at Northeastern University using Statistical Mechanics. Based on DFT calculations by Colin Gallagher at Northeastern University
+u"""
 """,
     metal = "Cu",
     facet = "111",
@@ -370,7 +415,7 @@ entry(
 ),
     shortDesc = u"""OCHCH2X""",
     longDesc =
-u"""Calculated by Torrie Asifor at Northeastern University using Statistical Mechanics. Based on DFT calculations by Colin Gallagher at Northeastern University
+u"""
 """,
     metal = "Cu",
     facet = "111",
@@ -401,7 +446,7 @@ entry(
 ),
     shortDesc = u"""OCHCH3X""",
     longDesc =
-u"""Calculated by Torrie Asifor at Northeastern University using Statistical Mechanics. Based on DFT calculations by Colin Gallagher at Northeastern University
+u"""
 """,
     metal = "Cu",
     facet = "111",
@@ -432,7 +477,7 @@ entry(
 ),
     shortDesc = u"""OCHCHOHX""",
     longDesc =
-u"""Calculated by Torrie Asifor at Northeastern University using Statistical Mechanics. Based on DFT calculations by Colin Gallagher at Northeastern University
+u"""
 """,
     metal = "Cu",
     facet = "111",
@@ -461,7 +506,7 @@ entry(
 ),
     shortDesc = u"""OCHCHX""",
     longDesc =
-u"""Calculated by Torrie Asifor at Northeastern University using Statistical Mechanics. Based on DFT calculations by Colin Gallagher at Northeastern University
+u"""
 """,
     metal = "Cu",
     facet = "111",
@@ -492,7 +537,7 @@ entry(
 ),
     shortDesc = u"""OCHOCHX""",
     longDesc =
-u"""Calculated by Torrie Asifor at Northeastern University using Statistical Mechanics. Based on DFT calculations by Colin Gallagher at Northeastern University
+u"""
 """,
     metal = "Cu",
     facet = "111",
@@ -520,7 +565,7 @@ entry(
 ),
     shortDesc = u"""OCHOX""",
     longDesc =
-u"""Calculated by Torrie Asifor at Northeastern University using Statistical Mechanics. Based on DFT calculations by Colin Gallagher at Northeastern University
+u"""
 """,
     metal = "Cu",
     facet = "111",
@@ -549,7 +594,7 @@ entry(
 ),
     shortDesc = u"""XCOXCO""",
     longDesc =
-u"""Calculated by Torrie Asifor at Northeastern University using Statistical Mechanics. Based on DFT calculations by Colin Gallagher at Northeastern University
+u"""
 """,
     metal = "Cu",
     facet = "111",

--- a/input/thermo/libraries/CO2RR_Adsorbates_Cu3Sn0001.py
+++ b/input/thermo/libraries/CO2RR_Adsorbates_Cu3Sn0001.py
@@ -1,0 +1,391 @@
+#!/usr/bin/env python
+# encoding: utf-8
+
+name = "CO2RR_Adsorbates_Cu3Sn0001"
+solvent = "water"
+shortDesc = u"Place holder for short description"
+longDesc = u"""
+Place holder for long description
+"""
+
+entry(
+    index = 0,
+    label = "CHOX",
+    molecule =
+"""
+1 O u0 p2 c0 {2,D}
+2 C u0 p0 c0 {1,D} {3,S} {4,S}
+3 H u0 p0 c0 {2,S}
+4 X u0 p0 c0 {2,S}
+""",
+    thermo = NASA(
+    polynomials = [
+        NASAPolynomial(coeffs=[1.74349313, 0.0148300711, -1.65536121e-05, 1.03768953e-08, -2.77422703e-12, -14068.2838, -8.10961736], Tmin=(298.0, 'K'), Tmax=(1000.0, 'K')),
+        NASAPolynomial(coeffs=[7.60674062, -0.00396066968, 7.15100332e-06, -3.87857554e-09, 7.04121665e-13, -15569.5014, -37.7908267], Tmin=(1000.0, 'K'), Tmax=(2000.0, 'K')),
+    ],
+    Tmin=(298.0, 'K'),
+    Tmax=(2000.0, 'K'),
+),
+    shortDesc = u"""CHOX""",
+    longDesc =
+u"""Calculated by Torrie Asifor at Northeastern University using Statistical Mechanics. Based on DFT calculations by Colin Gallagher at Northeastern University
+""",
+    metal = "Cu3Sn",
+    facet = "0001",
+)
+
+
+entry(
+    index = 1,
+    label = "COCHOX",
+    molecule =
+"""
+1 O u0 p2 c0 {3,D}
+2 O u0 p2 c0 {4,D}
+3 C u0 p0 c0 {1,D} {4,S} {5,S}
+4 C u0 p0 c0 {2,D} {3,S} {6,S}
+5 H u0 p0 c0 {3,S}
+6 X u0 p0 c0 {4,S}
+""",
+    thermo = NASA(
+    polynomials = [
+        NASAPolynomial(coeffs=[2.51074428, 0.0220340273, -2.02688214e-05, 9.54750791e-09, -1.82176149e-12, -30765.8755, -4.81098828], Tmin=(298.0, 'K'), Tmax=(1000.0, 'K')),
+        NASAPolynomial(coeffs=[11.9774317, -0.0061910143, 1.12437071e-05, -6.15372406e-09, 1.12529604e-12, -33288.3219, -53.2387915], Tmin=(1000.0, 'K'), Tmax=(2000.0, 'K')),
+    ],
+    Tmin=(298.0, 'K'),
+    Tmax=(2000.0, 'K'),
+),
+    shortDesc = u"""COCHOX""",
+    longDesc =
+u"""Calculated by Torrie Asifor at Northeastern University using Statistical Mechanics. Based on DFT calculations by Colin Gallagher at Northeastern University
+""",
+    metal = "Cu3Sn",
+    facet = "0001",
+)
+
+
+entry(
+    index = 2,
+    label = "COOHX",
+    molecule =
+"""
+1 O u0 p2 c0 {3,S} {4,S}
+2 O u0 p2 c0 {3,D}
+3 C u0 p0 c0 {1,S} {2,D} {5,S}
+4 H u0 p0 c0 {1,S} 
+5 X u0 p0 c0 {3,S}
+""",
+    thermo = NASA(
+    polynomials = [
+        NASAPolynomial(coeffs=[1.57291532, 0.0239770732, -2.79387799e-05, 1.65750947e-08, -3.92695945e-12, -48808.2078, -6.7526346], Tmin=(298.0, 'K'), Tmax=(1000.0, 'K')),
+        NASAPolynomial(coeffs=[10.2432721, -0.0045092048, 8.09079692e-06, -4.35111478e-09, 7.85594402e-13, -50956.2429, -50.3765829], Tmin=(1000.0, 'K'), Tmax=(2000.0, 'K')),
+    ],
+    Tmin=(298.0, 'K'),
+    Tmax=(2000.0, 'K'),
+),
+    shortDesc = u"""COOHX""",
+    longDesc =
+u"""Calculated by Torrie Asifor at Northeastern University using Statistical Mechanics. Based on DFT calculations by Colin Gallagher at Northeastern University
+""",
+    metal = "Cu3Sn",
+    facet = "0001",
+)
+
+
+entry(
+    index = 3,
+    label = "COX",
+    molecule =
+"""
+1 O u0 p2 c0 {2,D}
+2 C u0 p0 c0 {1,D} {3,D}
+3 X u0 p0 c0 {2,D} 
+""",
+    thermo = NASA(
+    polynomials = [
+        NASAPolynomial(coeffs=[2.15374115, 0.00711964156, -1.13374895e-05, 1.00074377e-08, -3.47838511e-12, -19372.6808, -4.67420257], Tmin=(298.0, 'K'), Tmax=(1000.0, 'K')),
+        NASAPolynomial(coeffs=[4.45424836, -0.00162230699, 2.9503086e-06, -1.61116576e-09, 2.93861513e-13, -19914.6116, -16.0376878], Tmin=(1000.0, 'K'), Tmax=(2000.0, 'K')),
+    ],
+    Tmin=(298.0, 'K'),
+    Tmax=(2000.0, 'K'),
+),
+    shortDesc = u"""COX""",
+    longDesc =
+u"""Calculated by Torrie Asifor at Northeastern University using Statistical Mechanics. Based on DFT calculations by Colin Gallagher at Northeastern University
+""",
+    metal = "Cu3Sn",
+    facet = "0001",
+)
+
+
+entry(
+    index = 4,
+    label = "OCH2CH3X",
+    molecule =
+"""
+1 O u0 p2 c0 {2,S} {9,S}
+2 C u0 p0 c0 {1,S} {3,S} {4,S} {5,S}
+3 C u0 p0 c0 {2,S} {6,S} {7,S} {8,S}
+4 H u0 p0 c0 {2,S}
+5 H u0 p0 c0 {2,S}
+6 H u0 p0 c0 {3,S}
+7 H u0 p0 c0 {3,S}
+8 H u0 p0 c0 {3,S}
+9 X u0 p0 c0 {1,S}
+""",
+    thermo = NASA(
+    polynomials = [
+        NASAPolynomial(coeffs=[0.788155367, 0.0249548897, -2.96759698e-06, -1.24467075e-08, 6.52723015e-12, -34237.4683, 2.48957937], Tmin=(298.0, 'K'), Tmax=(1000.0, 'K')),
+        NASAPolynomial(coeffs=[16.8164772, -0.0159260566, 2.84392268e-05, -1.52019708e-08, 2.72829405e-12, -38845.6552, -81.1844559], Tmin=(1000.0, 'K'), Tmax=(2000.0, 'K')),
+    ],
+    Tmin=(298.0, 'K'),
+    Tmax=(2000.0, 'K'),
+),
+    shortDesc = u"""OCH2CH3X""",
+    longDesc =
+u"""Calculated by Torrie Asifor at Northeastern University using Statistical Mechanics. Based on DFT calculations by Colin Gallagher at Northeastern University
+""",
+    metal = "Cu3Sn",
+    facet = "0001",
+)
+
+
+entry(
+    index = 5,
+    label = "OCHCH2OHX",
+    molecule =
+"""
+1 O u0 p2 c0 {3,S} {8,S}
+2 O u0 p2 c0 {4,D}
+3 C u0 p0 c0 {1,S} {4,S} {5,S} {6,S}
+4 C u0 p0 c0 {2,D} {3,S} {7,S}
+5 H u0 p0 c0 {3,S}
+6 H u0 p0 c0 {3,S}
+7 H u0 p0 c0 {4,S}
+8 H u0 p0 c0 {1,S}
+9 X u0 p0 c0 
+""",
+    thermo = NASA(
+    polynomials = [
+        NASAPolynomial(coeffs=[2.97459822, 0.0242885566, -4.95324176e-06, -1.04154645e-08, 5.88135443e-12, -46058.3536, -4.8074186], Tmin=(298.0, 'K'), Tmax=(1000.0, 'K')),
+        NASAPolynomial(coeffs=[17.7412996, -0.0135023109, 2.41363604e-05, -1.29228777e-08, 2.32333159e-12, -50287.6975, -81.8408018], Tmin=(1000.0, 'K'), Tmax=(2000.0, 'K')),
+    ],
+    Tmin=(298.0, 'K'),
+    Tmax=(2000.0, 'K'),
+),
+    shortDesc = u"""OCHCH2OHX""",
+    longDesc =
+u"""Calculated by Torrie Asifor at Northeastern University using Statistical Mechanics. Based on DFT calculations by Colin Gallagher at Northeastern University
+""",
+    metal = "Cu3Sn",
+    facet = "0001",
+)
+
+
+entry(
+    index = 6,
+    label = "OCHCH2X",
+    molecule =
+"""
+1 O u0 p2 c0 {2,S} {7,S}
+2 C u0 p0 c0 {1,S} {3,D} {4,S}
+3 C u0 p0 c0 {2,D} {5,S} {6,S}
+4 H u0 p0 c0 {2,S}
+5 H u0 p0 c0 {3,S}
+6 H u0 p0 c0 {3,S}
+7 X u0 p0 c0 {1,S}
+""",
+    thermo = NASA(
+    polynomials = [
+        NASAPolynomial(coeffs=[-0.163426185, 0.0309141687, -2.93377835e-05, 1.44116925e-08, -2.69761991e-12, -22710.7822, 5.99423326], Tmin=(298.0, 'K'), Tmax=(1000.0, 'K')),
+        NASAPolynomial(coeffs=[13.0987573, -0.00985382394, 1.7589596e-05, -9.39193391e-09, 1.68443623e-12, -26156.9338, -61.4743534], Tmin=(1000.0, 'K'), Tmax=(2000.0, 'K')),
+    ],
+    Tmin=(298.0, 'K'),
+    Tmax=(2000.0, 'K'),
+),
+    shortDesc = u"""OCHCH2X""",
+    longDesc =
+u"""Calculated by Torrie Asifor at Northeastern University using Statistical Mechanics. Based on DFT calculations by Colin Gallagher at Northeastern University
+""",
+    metal = "Cu3Sn",
+    facet = "0001",
+)
+
+
+entry(
+    index = 7,
+    label = "OCHCH3X",
+    molecule =
+"""
+1 O u0 p2 c0 {3,D} 
+2 C u0 p0 c0 {3,S} {4,S} {5,S} {6,S}
+3 C u0 p0 c0 {1,D} {2,S} {7,S}
+4 H u0 p0 c0 {2,S}
+5 H u0 p0 c0 {2,S}
+6 H u0 p0 c0 {2,S}
+7 H u0 p0 c0 {3,S}
+8 X u0 p0 c0 
+""",
+    thermo = NASA(
+    polynomials = [
+        NASAPolynomial(coeffs=[3.00634079, 0.0152798875, 6.13476544e-06, -1.65540464e-08, 7.12691885e-12, -26918.8699, -4.30723606], Tmin=(298.0, 'K'), Tmax=(1000.0, 'K')),
+        NASAPolynomial(coeffs=[14.9615622, -0.0130702141, 2.33503201e-05, -1.24906387e-08, 2.24283666e-12, -30476.5943, -67.2821044], Tmin=(1000.0, 'K'), Tmax=(2000.0, 'K')),
+    ],
+    Tmin=(298.0, 'K'),
+    Tmax=(2000.0, 'K'),
+),
+    shortDesc = u"""OCHCH3X""",
+    longDesc =
+u"""Calculated by Torrie Asifor at Northeastern University using Statistical Mechanics. Based on DFT calculations by Colin Gallagher at Northeastern University
+""",
+    metal = "Cu3Sn",
+    facet = "0001",
+)
+
+
+entry(
+    index = 8,
+    label = "OCHCHOHX",
+    molecule =
+"""
+1 O u0 p2 c0 {3,S} {8,S}
+2 O u0 p2 c0 {4,S} {7,S} 
+3 C u0 p0 c0 {1,S} {4,D} {5,S}
+4 C u0 p0 c0 {2,S} {3,D} {6,S}
+5 H u0 p0 c0 {3,S}
+6 H u0 p0 c0 {4,S}
+7 H u0 p0 c0 {2,S}
+8 X u0 p0 c0 {1,S}
+""",
+    thermo = NASA(
+    polynomials = [
+        NASAPolynomial(coeffs=[1.31738489, 0.0337353549, -3.07765911e-05, 1.35163088e-08, -1.94956551e-12, -41257.9069, -0.331264019], Tmin=(298.0, 'K'), Tmax=(1000.0, 'K')),
+        NASAPolynomial(coeffs=[15.8143526, -0.0101891781, 1.81561425e-05, -9.67051827e-09, 1.73209325e-12, -45043.1443, -74.2060751], Tmin=(1000.0, 'K'), Tmax=(2000.0, 'K')),
+    ],
+    Tmin=(298.0, 'K'),
+    Tmax=(2000.0, 'K'),
+),
+    shortDesc = u"""OCHCHOHX""",
+    longDesc =
+u"""Calculated by Torrie Asifor at Northeastern University using Statistical Mechanics. Based on DFT calculations by Colin Gallagher at Northeastern University
+""",
+    metal = "Cu3Sn",
+    facet = "0001",
+)
+
+
+entry(
+    index = 9,
+    label = "OCHCHX",
+    molecule =
+"""
+1 O u0 p2 c0 {3,D}
+2 C u0 p0 c0 {3,S} {4,S} {6,D}
+3 C u0 p0 c0 {1,D} {2,S} {5,S}
+4 H u0 p0 c0 {2,S}
+5 H u0 p0 c0 {3,S}
+6 X u0 p0 c0 {2,D}
+""",
+    thermo = NASA(
+    polynomials = [
+        NASAPolynomial(coeffs=[-0.186083938, 0.0313033805, -3.31640683e-05, 1.83063923e-08, -4.06516487e-12, -16607.1771, -0.533154725], Tmin=(298.0, 'K'), Tmax=(1000.0, 'K')),
+        NASAPolynomial(coeffs=[12.1682959, -0.00776604449, 1.39731944e-05, -7.54695754e-09, 1.3659676e-12, -19762.1543, -63.1133931], Tmin=(1000.0, 'K'), Tmax=(2000.0, 'K')),
+    ],
+    Tmin=(298.0, 'K'),
+    Tmax=(2000.0, 'K'),
+),
+    shortDesc = u"""OCHCHX""",
+    longDesc =
+u"""Calculated by Torrie Asifor at Northeastern University using Statistical Mechanics. Based on DFT calculations by Colin Gallagher at Northeastern University
+""",
+    metal = "Cu3Sn",
+    facet = "0001",
+)
+
+
+entry(
+    index = 10,
+    label = "OCHOCHX",
+    molecule =
+"""
+1 O u0 p2 c0 {3,S} {7,S}
+2 O u0 p2 c0 {4,S} {8,S} 
+3 C u0 p0 c0 {1,S} {4,D} {5,S}
+4 C u0 p0 c0 {2,S} {3,D} {6,S}
+5 H u0 p0 c0 {3,S}
+6 H u0 p0 c0 {4,S}
+7 X u0 p0 c0 {1,S}
+8 X u0 p0 c0 {2,S}
+""",
+    thermo = NASA(
+    polynomials = [
+        NASAPolynomial(coeffs=[0.0579249054, 0.0344787757, -3.46894579e-05, 1.74808247e-08, -3.37110895e-12, -40845.0891, 4.97109633], Tmin=(298.0, 'K'), Tmax=(1000.0, 'K')),
+        NASAPolynomial(coeffs=[13.9289506, -0.00853520745, 1.53752974e-05, -8.32061068e-09, 1.50852866e-12, -44422.9436, -65.4843799], Tmin=(1000.0, 'K'), Tmax=(2000.0, 'K')),
+    ],
+    Tmin=(298.0, 'K'),
+    Tmax=(2000.0, 'K'),
+),
+    shortDesc = u"""OCHOCHX""",
+    longDesc =
+u"""Calculated by Torrie Asifor at Northeastern University using Statistical Mechanics. Based on DFT calculations by Colin Gallagher at Northeastern University
+""",
+    metal = "Cu3Sn",
+    facet = "0001",
+)
+
+
+entry(
+    index = 11,
+    label = "OCHOX",
+    molecule =
+"""
+1 O u0 p2 c0 {3,S} {5,S}
+2 O u0 p2 c0 {3,D} 
+3 C u0 p0 c0 {1,S} {2,D} {4,S}
+4 H u0 p0 c0 {3,S}
+5 X u0 p0 c0 {1,S}
+""",
+    thermo = NASA(
+    polynomials = [
+        NASAPolynomial(coeffs=[1.67220889, 0.0144593325, -7.37932862e-06, -1.33628765e-09, 1.74722736e-12, -57413.8836, -1.50759757], Tmin=(298.0, 'K'), Tmax=(1000.0, 'K')),
+        NASAPolynomial(coeffs=[9.14577907, -0.00549354708, 9.94099598e-06, -5.41764493e-09, 9.87569455e-13, -59512.1847, -40.2901072], Tmin=(1000.0, 'K'), Tmax=(2000.0, 'K')),
+    ],
+    Tmin=(298.0, 'K'),
+    Tmax=(2000.0, 'K'),
+),
+    shortDesc = u"""OCHOX""",
+    longDesc =
+u"""Calculated by Torrie Asifor at Northeastern University using Statistical Mechanics. Based on DFT calculations by Colin Gallagher at Northeastern University
+""",
+    metal = "Cu3Sn",
+    facet = "0001",
+)
+
+
+entry(
+    index = 12,
+    label = "XCOXCO",
+    molecule =
+"""
+1 O u0 p2 c0 {3,D}
+2 O u0 p2 c0 {4,D}
+3 C u0 p0 c0 {1,D} {4,S} {5,S}
+4 C u0 p0 c0 {2,D} {3,S} {6,S}
+5 X u0 p0 c0 {3,S}
+6 X u0 p0 c0 {4,S}
+""",
+    thermo = NASA(
+    polynomials = [
+        NASAPolynomial(coeffs=[2.41884657, 0.0278294959, -3.94623871e-05, 2.87941258e-08, -8.50641432e-12, -26978.4777, -12.375979], Tmin=(298.0, 'K'), Tmax=(1000.0, 'K')),
+        NASAPolynomial(coeffs=[11.0515201, -0.00331790688, 6.11806441e-06, -3.41065788e-09, 6.32647174e-13, -29007.55, -55.2010354], Tmin=(1000.0, 'K'), Tmax=(2000.0, 'K')),
+    ],
+    Tmin=(298.0, 'K'),
+    Tmax=(2000.0, 'K'),
+),
+    shortDesc = u"""XCOXCO""",
+    longDesc =
+u"""Calculated by Torrie Asifor at Northeastern University using Statistical Mechanics. Based on DFT calculations by Colin Gallagher at Northeastern University
+""",
+    metal = "Cu3Sn",
+    facet = "0001",
+)

--- a/input/thermo/libraries/CO2RR_Adsorbates_Cu3Sn0001.py
+++ b/input/thermo/libraries/CO2RR_Adsorbates_Cu3Sn0001.py
@@ -2,10 +2,58 @@
 # encoding: utf-8
 
 name = "CO2RR_Adsorbates_Cu3Sn0001"
-solvent = "water"
-shortDesc = u"Place holder for short description"
-longDesc = u"""
-Place holder for long description
+shortDesc = "CO2RR adsorbate thermochemistry on Cu3Sn(0001) from DFT"
+longDesc = """
+NASA polynomial thermochemistry for C1 and C2 adsorbate intermediates
+relevant to electrochemical CO2 reduction (CO2RR) on the Cu3Sn(0001)
+surface of the epsilon-Cu3Sn intermetallic. Species include CHOX, COX,
+COOHX, OCHOX, COCHOX, the C-C coupled XCOXCO dimer, and the C2 alkoxy
+and enol intermediates OCHCHX, OCHCH2X, OCHCH3X, OCHCHOHX, OCHCH2OHX,
+OCHOCHX, and OCH2CH3X. Adsorbates are labeled with a trailing or
+interleaved 'X' to indicate surface binding sites, per RMG conventions.
+
+DFT (Colin Gallagher, Northeastern): VASP with PBE + Grimme D3 zero-damping
+(IVDW = 12) and PAW pseudopotentials. A two-stage protocol was used:
+initial geometries were pre-optimized at ENCUT = 400 eV with a 3x3x1
+Monkhorst-Pack k-mesh, then fully re-relaxed to force convergence at
+tighter settings of ENCUT = 500 eV and 4x4x1 k-mesh (IBRION = 2,
+EDIFFG = -0.03 eV/A). All final energies - adsorbate slabs, bare-slab
+reference, and vibrational frequencies - were computed at the tight
+settings. Other parameters: 1st order Methfessel-Paxton smearing
+(ISMEAR = 1) with a smearing width of 0.1 eV, ISPIN = 2,
+EDIFF = 1E-6 eV, no dipole correction. Slab: hexagonal Cu3Sn(0001)
+supercell with 48 Cu + 16 Sn across 5 layers (bottom 3 fixed, top 2
+relaxed), in-plane area 104.37 A^2, ~17 A vacuum. Harmonic frequencies
+from finite differences (IBRION = 5, NFREE = 2, POTIM = 0.015 A) on the
+free atoms (adsorbate + top 2 layers).
+
+Post-processing and thermo (Torrie Asifor) via the Westgroup pipeline
+(adapted from input_generator.py and compute_NASA_for_adsorbates): VASP
+outputs converted to ASE .traj and inspected; vibrational frequencies
+and ZPEs consolidated into per-species zpe_log_<species>.txt files;
+imaginary modes replaced with 12 cm^-1. Heat of formation at 0 K was
+computed from a thermochemical cycle against CH4, H2O, and H2 references
+(ATcT: h0_CH4 = -66.556 kJ/mol, h0_H2O = -238.938 kJ/mol,
+h0_H2 = 0.0 kJ/mol). Reference gas electronic energies were read from the
+final frame of each gas's ads_vib.traj at the same PBE+D3 level as the
+slabs (displaced rather than relaxed geometries, a systematic ~1 kJ/mol
+offset shared across all species); hard-coded ZPEs ZPE_CH4 = 1.196 eV,
+ZPE_H2 = 0.277 eV, ZPE_H2O = 0.609 eV were used. Partition functions
+were evaluated over 298.15-2000 K with the harmonic oscillator
+approximation; when an adsorbate's two lowest modes fall below 100 cm^-1
+they are replaced by a 2D-gas translational model using a legacy per-site
+area of 6.90 A^2/site inherited from earlier 3x3 Cu(111) workflows (vs.
+the actual 6.52 A^2/site for this Cu3Sn slab, a ~0.15 kJ/mol shift at
+298 K). NASA polynomials were fit in two ranges (298-1000 K,
+1000-2000 K) by least-squares regression of Cp/R with enthalpy and
+entropy matched at 298.15 K and continuity enforced at 1000 K. Heats of
+formation were corrected from 0 K to 298 K using tabulated atomic
+H(298)-H(0) increments.
+
+Primary DFT-based thermo reference for RMG-generated CO2RR mechanisms on
+Cu3Sn(0001) in the Westgroup automated microkinetic modeling pipeline.
+Uncertainty is consistent with typical PBE+D3 performance on
+transition-metal adsorbates (~0.2 eV, ~20 kJ/mol per species).
 """
 
 entry(
@@ -28,7 +76,7 @@ entry(
 ),
     shortDesc = u"""CHOX""",
     longDesc =
-u"""Calculated by Torrie Asifor at Northeastern University using Statistical Mechanics. Based on DFT calculations by Colin Gallagher at Northeastern University
+u"""
 """,
     metal = "Cu3Sn",
     facet = "0001",
@@ -57,7 +105,7 @@ entry(
 ),
     shortDesc = u"""COCHOX""",
     longDesc =
-u"""Calculated by Torrie Asifor at Northeastern University using Statistical Mechanics. Based on DFT calculations by Colin Gallagher at Northeastern University
+u"""
 """,
     metal = "Cu3Sn",
     facet = "0001",
@@ -85,7 +133,7 @@ entry(
 ),
     shortDesc = u"""COOHX""",
     longDesc =
-u"""Calculated by Torrie Asifor at Northeastern University using Statistical Mechanics. Based on DFT calculations by Colin Gallagher at Northeastern University
+u"""
 """,
     metal = "Cu3Sn",
     facet = "0001",
@@ -111,7 +159,7 @@ entry(
 ),
     shortDesc = u"""COX""",
     longDesc =
-u"""Calculated by Torrie Asifor at Northeastern University using Statistical Mechanics. Based on DFT calculations by Colin Gallagher at Northeastern University
+u"""
 """,
     metal = "Cu3Sn",
     facet = "0001",
@@ -143,7 +191,7 @@ entry(
 ),
     shortDesc = u"""OCH2CH3X""",
     longDesc =
-u"""Calculated by Torrie Asifor at Northeastern University using Statistical Mechanics. Based on DFT calculations by Colin Gallagher at Northeastern University
+u"""
 """,
     metal = "Cu3Sn",
     facet = "0001",
@@ -175,7 +223,7 @@ entry(
 ),
     shortDesc = u"""OCHCH2OHX""",
     longDesc =
-u"""Calculated by Torrie Asifor at Northeastern University using Statistical Mechanics. Based on DFT calculations by Colin Gallagher at Northeastern University
+u"""
 """,
     metal = "Cu3Sn",
     facet = "0001",
@@ -205,7 +253,7 @@ entry(
 ),
     shortDesc = u"""OCHCH2X""",
     longDesc =
-u"""Calculated by Torrie Asifor at Northeastern University using Statistical Mechanics. Based on DFT calculations by Colin Gallagher at Northeastern University
+u"""
 """,
     metal = "Cu3Sn",
     facet = "0001",
@@ -236,7 +284,7 @@ entry(
 ),
     shortDesc = u"""OCHCH3X""",
     longDesc =
-u"""Calculated by Torrie Asifor at Northeastern University using Statistical Mechanics. Based on DFT calculations by Colin Gallagher at Northeastern University
+u"""
 """,
     metal = "Cu3Sn",
     facet = "0001",
@@ -267,7 +315,7 @@ entry(
 ),
     shortDesc = u"""OCHCHOHX""",
     longDesc =
-u"""Calculated by Torrie Asifor at Northeastern University using Statistical Mechanics. Based on DFT calculations by Colin Gallagher at Northeastern University
+u"""
 """,
     metal = "Cu3Sn",
     facet = "0001",
@@ -296,7 +344,7 @@ entry(
 ),
     shortDesc = u"""OCHCHX""",
     longDesc =
-u"""Calculated by Torrie Asifor at Northeastern University using Statistical Mechanics. Based on DFT calculations by Colin Gallagher at Northeastern University
+u"""
 """,
     metal = "Cu3Sn",
     facet = "0001",
@@ -327,7 +375,7 @@ entry(
 ),
     shortDesc = u"""OCHOCHX""",
     longDesc =
-u"""Calculated by Torrie Asifor at Northeastern University using Statistical Mechanics. Based on DFT calculations by Colin Gallagher at Northeastern University
+u"""
 """,
     metal = "Cu3Sn",
     facet = "0001",
@@ -355,7 +403,7 @@ entry(
 ),
     shortDesc = u"""OCHOX""",
     longDesc =
-u"""Calculated by Torrie Asifor at Northeastern University using Statistical Mechanics. Based on DFT calculations by Colin Gallagher at Northeastern University
+u"""
 """,
     metal = "Cu3Sn",
     facet = "0001",
@@ -384,7 +432,7 @@ entry(
 ),
     shortDesc = u"""XCOXCO""",
     longDesc =
-u"""Calculated by Torrie Asifor at Northeastern University using Statistical Mechanics. Based on DFT calculations by Colin Gallagher at Northeastern University
+u"""
 """,
     metal = "Cu3Sn",
     facet = "0001",


### PR DESCRIPTION
Added DFT-based thermo libraries for CO2 reduction adsorbates on Cu(111) and Cu3Sn(0001) surfaces.

CO2RR_Adsorbates_Cu111.py: Thermo data for adsorbates on Cu(111)
CO2RR_Adsorbates_Cu3Sn0001.py: Thermo data for adsorbates on Cu3Sn(0001)

Raw DFT data calculated by Colin Gallagher from Northeastern University. Converted to RMG data format by Torrie Asifor.